### PR TITLE
Fix typo in documentation when whitelisting SAFE_PROTOTYPES

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can set your own whilelisted prototypes and global properties like so (`aler
 
 ```javascript
 const allowedPrototypes = Sandbox.SAFE_PROTOTYPES;
-allowedPrototypes.add(Node, []);
+allowedPrototypes.set(Node, []);
 
 const allowedGlobals = Sandbox.SAFE_GLOBALS;
 allowedGlobals.alert = alert;


### PR DESCRIPTION
Small typo in the documentation. 
SAFE_PROTOTYPES is a Map and not a Set so the method to use is SAFE_PROTOTYPES.set(prototype, [])