### PR TITLE
fix: sandbox wrapper resolution and global property handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nyariv/sandboxjs",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nyariv/sandboxjs",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -7077,9 +7077,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nyariv/sandboxjs",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Javascript sandboxing library.",
   "main": "dist/cjs/Sandbox.js",
   "module": "./dist/esm/Sandbox.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
       "require": "./dist/cjs/SandboxExec.js",
       "default": "./dist/esm/SandboxExec.js"
     },
-    "./dist/*": "./dist/*",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/src/Sandbox.ts
+++ b/src/Sandbox.ts
@@ -1,4 +1,4 @@
-import { createExecContext, SandboxCapabilityError, sanitizeScopes } from './utils';
+import { AsyncFunction, createExecContext, SandboxCapabilityError, sanitizeScopes } from './utils';
 import type { IExecContext, IOptionParams, IScope } from './utils';
 import { createEvalContext } from './eval';
 import { ExecReturn } from './executor';
@@ -48,6 +48,60 @@ export class Sandbox extends SandboxExec {
     return parse(code, true);
   }
 
+  get Function() {
+    const context = createExecContext(
+      this,
+      {
+        tree: [],
+        constants: {
+          strings: [],
+          eager: true,
+          literals: [],
+          maxDepth: this.context.options.maxParserRecursionDepth,
+          regexes: [],
+        },
+      },
+      this.evalContext,
+    );
+    return context.evals.get(Function)!;
+  }
+
+  get AsyncFunction() {
+    const context = createExecContext(
+      this,
+      {
+        tree: [],
+        constants: {
+          strings: [],
+          eager: true,
+          literals: [],
+          maxDepth: this.context.options.maxParserRecursionDepth,
+          regexes: [],
+        },
+      },
+      this.evalContext,
+    );
+    return context.evals.get(AsyncFunction)!;
+  }
+
+  get eval() {
+    const context = createExecContext(
+      this,
+      {
+        tree: [],
+        constants: {
+          strings: [],
+          eager: true,
+          literals: [],
+          maxDepth: this.context.options.maxParserRecursionDepth,
+          regexes: [],
+        },
+      },
+      this.evalContext,
+    );
+    return context.evals.get(eval)!;
+  }
+
   compile<T>(
     code: string,
     optimize = false,
@@ -57,8 +111,8 @@ export class Sandbox extends SandboxExec {
         'Non-blocking mode is enabled, use Sandbox.compileAsync() instead.',
       );
     const parsed = parse(code, optimize, false, this.context.options.maxParserRecursionDepth);
+    const context = createExecContext(this, parsed, this.evalContext);
     const exec = (...scopes: IScope[]) => {
-      const context = createExecContext(this, parsed, this.evalContext);
       sanitizeScopes(scopes, context);
       return { context, run: () => this.executeTree<T>(context, [...scopes]).result };
     };
@@ -70,8 +124,8 @@ export class Sandbox extends SandboxExec {
     optimize = false,
   ): (...scopes: IScope[]) => { context: IExecContext; run: () => Promise<T> } {
     const parsed = parse(code, optimize, false, this.context.options.maxParserRecursionDepth);
+    const context = createExecContext(this, parsed, this.evalContext);
     const exec = (...scopes: IScope[]) => {
-      const context = createExecContext(this, parsed, this.evalContext);
       sanitizeScopes(scopes, context);
       return {
         context,
@@ -86,8 +140,8 @@ export class Sandbox extends SandboxExec {
     optimize = false,
   ): (...scopes: IScope[]) => { context: IExecContext; run: () => T } {
     const parsed = parse(code, optimize, true, this.context.options.maxParserRecursionDepth);
+    const context = createExecContext(this, parsed, this.evalContext);
     const exec = (...scopes: IScope[]) => {
-      const context = createExecContext(this, parsed, this.evalContext);
       sanitizeScopes(scopes, context);
       return { context, run: () => this.executeTree<T>(context, [...scopes]).result };
     };
@@ -99,8 +153,8 @@ export class Sandbox extends SandboxExec {
     optimize = false,
   ): (...scopes: IScope[]) => { context: IExecContext; run: () => Promise<T> } {
     const parsed = parse(code, optimize, true, this.context.options.maxParserRecursionDepth);
+    const context = createExecContext(this, parsed, this.evalContext);
     const exec = (...scopes: IScope[]) => {
-      const context = createExecContext(this, parsed, this.evalContext);
       return {
         context,
         run: () => this.executeTreeAsync<T>(context, [...scopes]).then((ret) => ret.result),

--- a/src/SandboxExec.ts
+++ b/src/SandboxExec.ts
@@ -13,15 +13,6 @@ import type {
   HaltContext,
 } from './utils';
 
-export type { IOptions, IContext, IExecContext } from './utils';
-export {
-  LocalScope,
-  SandboxExecutionTreeError,
-  SandboxCapabilityError,
-  SandboxAccessError,
-  SandboxError,
-} from './utils';
-
 function subscribeSet(
   obj: object,
   name: string,
@@ -100,7 +91,10 @@ export class SandboxExec {
         prototypeWhitelist: SandboxExec.SAFE_PROTOTYPES,
         maxParserRecursionDepth: 256,
         nonBlocking: false,
-        functionReplacements: new Map<Function, (ctx: IContext) => Function>(),
+        functionReplacements: new Map<
+          Function,
+          (ctx: IExecContext, builtInReplacement?: Function) => Function
+        >(),
       },
       options || {},
     );

--- a/src/executor/ops/call.ts
+++ b/src/executor/ops/call.ts
@@ -38,7 +38,7 @@ addOps<unknown, Lisp[], any>(LispType.Call, (params) => {
 
   if (a === String) {
     const result = String(vals[0]);
-    checkTicksAndThrow(context.ctx, BigInt(result.length));
+    checkTicksAndThrow(context, BigInt(result.length));
     done(undefined, result);
     return;
   }
@@ -77,7 +77,7 @@ addOps<unknown, Lisp[], any>(LispType.Call, (params) => {
       }
     };
     recurse(vals[0]);
-    checkTicksAndThrow(context.ctx, ticks);
+    checkTicksAndThrow(context, ticks);
   }
 
   if (
@@ -137,10 +137,12 @@ addOps<unknown, Lisp[], any>(LispType.Call, (params) => {
     }
   }
 
-  // Trigger get-subscriptions, then call via `a` (which may be a tick-checking replacement)
+  // Trigger get-subscriptions, then call via `a` (which may be a replacement from evals).
+  // Sandboxed wrappers for globals (Function, eval, etc.) must be called without `this`;
+  // tick-checking replacements must be called with `this`.
   obj.get(context);
   const evl = context.evals.get(originalFn as Function);
-  let ret = evl ? evl(...vals) : (a as Function).call(obj.context, ...vals);
+  let ret = evl ? evl.call(obj.context, ...vals) : (a as Function).call(obj.context, ...vals);
   ret = sanitizeProp(ret, context);
   if (ret !== null && typeof ret === 'object' && ret instanceof DelayedSynchronousResult) {
     Promise.resolve(ret.result).then(
@@ -158,7 +160,7 @@ addOps<new (...args: unknown[]) => void, unknown[]>(LispType.New, (params) => {
     throw new SandboxAccessError(`Object construction not allowed: ${a.constructor.name}`);
   }
   const vals = b.map((item) => sanitizeProp(item, context));
-  const replacement = context.ctx.functionReplacements.get(a);
+  const replacement = context.evals.get(a);
   if (replacement) {
     const ret = new (replacement as new (...args: unknown[]) => unknown)(...vals);
     done(undefined, ret);

--- a/src/executor/ops/call.ts
+++ b/src/executor/ops/call.ts
@@ -6,6 +6,7 @@ import {
 import type { Lisp } from '../../parser';
 import {
   DelayedSynchronousResult,
+  getReplacementReceiver,
   LispType,
   SandboxAccessError,
   SandboxCapabilityError,
@@ -46,7 +47,12 @@ addOps<unknown, Lisp[], any>(LispType.Call, (params) => {
   if (typeof obj === 'function') {
     // Direct function call (not a method): obj is the function itself
     const evl = context.evals.get(obj);
-    let ret = evl ? evl(obj, ...vals) : obj(...vals);
+    const receiver = getReplacementReceiver(obj);
+    let ret = evl
+      ? evl(obj, ...vals)
+      : receiver === undefined
+        ? obj(...vals)
+        : obj.call(receiver, ...vals);
     ret = sanitizeProp(ret, context);
     if (ret !== null && typeof ret === 'object' && ret instanceof DelayedSynchronousResult) {
       Promise.resolve(ret.result).then(
@@ -142,7 +148,9 @@ addOps<unknown, Lisp[], any>(LispType.Call, (params) => {
   // tick-checking replacements must be called with `this`.
   obj.get(context);
   const evl = context.evals.get(originalFn as Function);
-  let ret = evl ? evl.call(obj.context, ...vals) : (a as Function).call(obj.context, ...vals);
+  const receiver = getReplacementReceiver(originalFn as Function);
+  const thisArg = obj.isVariable && receiver !== undefined ? receiver : obj.context;
+  let ret = evl ? evl.call(thisArg, ...vals) : (a as Function).call(thisArg, ...vals);
   ret = sanitizeProp(ret, context);
   if (ret !== null && typeof ret === 'object' && ret instanceof DelayedSynchronousResult) {
     Promise.resolve(ret.result).then(

--- a/src/executor/ops/literals.ts
+++ b/src/executor/ops/literals.ts
@@ -16,7 +16,7 @@ addOps<unknown, string>(LispType.RegexIndex, ({ done, b, context }) => {
     throw new SandboxCapabilityError('Regex not permitted');
   } else {
     const RegExpCtor =
-      (context.ctx.functionReplacements.get(RegExp) as
+      (context.evals.get(RegExp) as
         | (new (pattern: string, flags?: string) => unknown)
         | undefined) ?? RegExp;
     done(undefined, new RegExpCtor(reg.regex, reg.flags));

--- a/src/executor/ops/prop.ts
+++ b/src/executor/ops/prop.ts
@@ -109,7 +109,9 @@ addOps<unknown, PropertyKey>(LispType.Prop, ({ done, a, b, obj, context, scope, 
     (!isSandboxGlobal && obj instanceof Prop && obj.isGlobal) ||
     (typeof a === 'function' && !context.ctx.sandboxedFunctions.has(a)) ||
     context.ctx.globalsWhitelist.has(a) ||
-    (isSandboxGlobal && typeof b === 'string' && b in context.ctx.globalScope.globals);
+    (isSandboxGlobal &&
+      typeof b === 'string' &&
+      hasOwnProperty(context.ctx.globalScope.globals, b));
 
   done(undefined, new Prop(a, b, false, g, false));
 });

--- a/src/executor/ops/prop.ts
+++ b/src/executor/ops/prop.ts
@@ -1,5 +1,11 @@
 import { addOps, hasPossibleProperties, isPropertyKey } from '../executorUtils';
-import { LispType, Prop, SandboxAccessError, getGlobalProp, hasOwnProperty } from '../../utils';
+import {
+  LispType,
+  Prop,
+  SandboxAccessError,
+  resolveSandboxProp,
+  hasOwnProperty,
+} from '../../utils';
 
 addOps<unknown, PropertyKey>(LispType.Prop, ({ done, a, b, obj, context, scope, internal }) => {
   if (a === null) {
@@ -22,7 +28,7 @@ addOps<unknown, PropertyKey>(LispType.Prop, ({ done, a, b, obj, context, scope, 
       }
     }
     const val = (prop.context as any)[prop.prop];
-    const p = getGlobalProp(val, context, prop) || prop;
+    const p = resolveSandboxProp(val, context, prop) || prop;
 
     done(undefined, p);
     return;
@@ -98,7 +104,7 @@ addOps<unknown, PropertyKey>(LispType.Prop, ({ done, a, b, obj, context, scope, 
     throw new SandboxAccessError(`Access to prototype of global object is not permitted`);
   }
 
-  const p = getGlobalProp(val, context, new Prop(a, b, false, false));
+  const p = resolveSandboxProp(val, context, new Prop(a, b, false, false));
   if (p) {
     done(undefined, p);
     return;

--- a/src/utils/ExecContext.ts
+++ b/src/utils/ExecContext.ts
@@ -18,6 +18,7 @@ import {
   type SubscriptionSubject,
 } from './types';
 import { Scope } from './Scope';
+import { hasOwnProperty } from './Prop';
 
 export class ExecContext implements IExecContext {
   constructor(
@@ -146,16 +147,7 @@ export function createContext(sandbox: SandboxExec, options: IOptions): IContext
       nextYield: options.nonBlocking ? NON_BLOCKING_THRESHOLD : undefined,
     },
     sandboxedFunctions: new WeakSet<Function>(),
-    functionReplacements: new Map<Function, Function>(),
   };
-  // Resolve default tick-checking replacements
-  for (const [original, factory] of DEFAULT_FUNCTION_REPLACEMENTS) {
-    context.functionReplacements.set(original, factory(context));
-  }
-  // Resolve user-provided replacements (override defaults)
-  for (const [original, factory] of options.functionReplacements) {
-    context.functionReplacements.set(original, factory(context));
-  }
   context.prototypeWhitelist.set(Object.getPrototypeOf(sandboxGlobal), new Set());
   context.prototypeWhitelist.set(Object.getPrototypeOf([][Symbol.iterator]()) as object, new Set());
   // Whitelist Generator and AsyncGenerator prototype chains
@@ -190,7 +182,7 @@ export function createExecContext(
     sandbox.setSubscriptions,
     sandbox.changeSubscriptions,
     evals,
-    (fn) => sandbox.sandboxFunctions.set(fn, execContext),
+    (fn: any) => sandbox.sandboxFunctions.set(fn, execContext),
     !!evalContext,
     evalContext,
   );
@@ -211,14 +203,27 @@ export function createExecContext(
     evals.set(clearTimeout, evalContext.sandboxedClearTimeout(execContext));
     evals.set(clearInterval, evalContext.sandboxedClearInterval(execContext));
 
+    for (const [original, factory] of DEFAULT_FUNCTION_REPLACEMENTS) {
+      evals.set(original, factory(execContext));
+    }
+
+    for (const [original, factory] of sandbox.context.options.functionReplacements) {
+      evals.set(original, factory(execContext, evals.get(original)));
+    }
+
+    const ptwl = sandbox.context.prototypeWhitelist;
+
     for (const [key, value] of evals) {
-      execContext.registerSandboxFunction(value as (...args: any[]) => any);
-      sandbox.context.prototypeWhitelist.set(value.prototype, new Set());
-      sandbox.context.prototypeWhitelist.set(key.prototype, new Set());
+      if (!ptwl.has(key.prototype)) {
+        ptwl.set(key.prototype, new Set());
+      }
+      if (!ptwl.has(value.prototype)) {
+        ptwl.set(value.prototype, ptwl.get(key.prototype) || new Set());
+      }
       if (sandbox.context.globalsWhitelist.has(key)) {
         sandbox.context.globalsWhitelist.add(value);
       }
-      if (sandbox.context.sandboxGlobal[key.name]) {
+      if (hasOwnProperty(sandbox.context.sandboxGlobal, key.name)) {
         sandbox.context.sandboxGlobal[key.name] = value;
       }
     }

--- a/src/utils/Prop.ts
+++ b/src/utils/Prop.ts
@@ -1,4 +1,8 @@
 import type { IExecContext } from './types';
+import { THIS_DEPENDENT_FUNCTION_REPLACEMENTS } from './functionReplacements';
+
+const boundFunctionCache = new WeakMap<Function, WeakMap<object, Function>>();
+const replacementReceiver = new WeakMap<Function, object>();
 
 export class Prop<T = unknown> {
   constructor(
@@ -17,11 +21,7 @@ export class Prop<T = unknown> {
       throw new TypeError(`Cannot read properties of null, (reading '${this.prop.toString()}')`);
     context.getSubscriptions.forEach((cb) => cb(ctx, this.prop.toString()));
     const val = (ctx as any)[this.prop];
-    if (typeof val === 'function') {
-      const replacement = context.evals.get(val);
-      if (replacement !== undefined) return replacement as T;
-    }
-    return val as T;
+    return getReplacementValue(val, context, ctx) as T;
   }
 }
 
@@ -29,7 +29,11 @@ export function hasOwnProperty(obj: unknown, prop: PropertyKey): boolean {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-export function getGlobalProp(val: unknown, context: IExecContext, prop?: Prop) {
+export function getReplacementReceiver(fn: Function) {
+  return replacementReceiver.get(fn);
+}
+
+export function resolveSandboxProp(val: unknown, context: IExecContext, prop?: Prop) {
   if (!val) return;
   if (val instanceof Prop) {
     if (!prop) {
@@ -49,8 +53,85 @@ export function getGlobalProp(val: unknown, context: IExecContext, prop?: Prop) 
       prop?.isVariable || false,
     );
   }
-  const evl = context.ctx.globalsWhitelist.has(val) && context.evals.get(val as Function);
-  if (evl) {
-    return new Prop({ [p]: evl }, p, prop?.isConst || false, true, prop?.isVariable || false);
+  if (prop && !prop.isVariable) {
+    return;
+  }
+  const replacement = getReplacementValue(val, context, prop?.context);
+  if (replacement !== val) {
+    return new Prop(
+      { [p]: replacement },
+      p,
+      prop?.isConst || false,
+      prop?.isGlobal || false,
+      prop?.isVariable || false,
+    );
+  }
+}
+
+function getReplacementValue(val: unknown, context: IExecContext, bindContext?: unknown) {
+  if (typeof val !== 'function') {
+    return val;
+  }
+  const replacement = context.evals.get(val as Function);
+  if (replacement === undefined) {
+    return val;
+  }
+  if (!shouldBindReplacement(val as Function, bindContext, context)) {
+    return replacement;
+  }
+  return bindReplacement(replacement, bindContext as object, val as Function, context);
+}
+
+function shouldBindReplacement(original: Function, bindContext: unknown, context: IExecContext) {
+  return (
+    THIS_DEPENDENT_FUNCTION_REPLACEMENTS.has(original) &&
+    bindContext !== null &&
+    (typeof bindContext === 'object' || typeof bindContext === 'function') &&
+    bindContext !== context.ctx.sandboxGlobal &&
+    !context.ctx.globalsWhitelist.has(bindContext)
+  );
+}
+
+function bindReplacement(
+  replacement: Function,
+  bindContext: object,
+  original: Function,
+  context: IExecContext,
+) {
+  let cache = boundFunctionCache.get(replacement);
+  if (!cache) {
+    cache = new WeakMap<object, Function>();
+    boundFunctionCache.set(replacement, cache);
+  }
+
+  let bound = cache.get(bindContext);
+  if (bound) {
+    return bound;
+  }
+
+  bound = function (this: unknown, ...args: unknown[]) {
+    return replacement.apply(this, args);
+  };
+
+  redefineFunctionMetadata(bound, original);
+  context.ctx.sandboxedFunctions.add(bound);
+  replacementReceiver.set(bound, bindContext);
+  cache.set(bindContext, bound);
+  return bound;
+}
+
+function redefineFunctionMetadata(
+  target: Function,
+  source: Function,
+  overrides: Partial<Record<'name' | 'length', string | number>> = {},
+) {
+  for (const key of ['name', 'length'] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (descriptor?.configurable) {
+      Object.defineProperty(target, key, {
+        ...descriptor,
+        value: overrides[key] ?? source[key],
+      });
+    }
   }
 }

--- a/src/utils/Prop.ts
+++ b/src/utils/Prop.ts
@@ -18,7 +18,7 @@ export class Prop<T = unknown> {
     context.getSubscriptions.forEach((cb) => cb(ctx, this.prop.toString()));
     const val = (ctx as any)[this.prop];
     if (typeof val === 'function') {
-      const replacement = context.ctx.functionReplacements.get(val);
+      const replacement = context.evals.get(val);
       if (replacement !== undefined) return replacement as T;
     }
     return val as T;
@@ -31,7 +31,6 @@ export function hasOwnProperty(obj: unknown, prop: PropertyKey): boolean {
 
 export function getGlobalProp(val: unknown, context: IExecContext, prop?: Prop) {
   if (!val) return;
-  const isFunc = typeof val === 'function';
   if (val instanceof Prop) {
     if (!prop) {
       prop = val;
@@ -50,16 +49,8 @@ export function getGlobalProp(val: unknown, context: IExecContext, prop?: Prop) 
       prop?.isVariable || false,
     );
   }
-  const evl = isFunc && context.evals.get(val as Function);
+  const evl = context.ctx.globalsWhitelist.has(val) && context.evals.get(val as Function);
   if (evl) {
-    return new Prop(
-      {
-        [p]: evl,
-      },
-      p,
-      prop?.isConst || false,
-      true,
-      prop?.isVariable || false,
-    );
+    return new Prop({ [p]: evl }, p, prop?.isConst || false, true, prop?.isVariable || false);
   }
 }

--- a/src/utils/Scope.ts
+++ b/src/utils/Scope.ts
@@ -45,7 +45,13 @@ export class Scope {
     if (internal && scope.internalVars[key]) {
       return new Prop(scope.internalVars, key, false, false, true, true);
     }
-    return new Prop(scope.allVars, key, key in scope.const, key in scope.globals, true);
+    return new Prop(
+      scope.allVars,
+      key,
+      hasOwnProperty(scope.const, key),
+      hasOwnProperty(scope.globals, key),
+      true,
+    );
   }
 
   set(key: string, val: unknown, internal: boolean) {

--- a/src/utils/Scope.ts
+++ b/src/utils/Scope.ts
@@ -1,5 +1,5 @@
 import { reservedWords, VarType } from './types';
-import { Prop, getGlobalProp, hasOwnProperty } from './Prop';
+import { Prop, resolveSandboxProp, hasOwnProperty } from './Prop';
 import { SandboxError } from './errors';
 import type { IExecContext, IScope } from './types';
 
@@ -186,7 +186,7 @@ export function sanitizeProp(
 ): unknown {
   if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return value;
 
-  value = getGlobalProp(value, context) || value;
+  value = resolveSandboxProp(value, context) || value;
 
   if (value instanceof Prop) {
     value = value.get(context);

--- a/src/utils/functionReplacements.ts
+++ b/src/utils/functionReplacements.ts
@@ -409,6 +409,7 @@ const staticObjectMethods = new Set<Function>([
 // ---------------------------------------------------------------------------
 
 export const DEFAULT_FUNCTION_REPLACEMENTS = new Map<Function, Factory>();
+export const THIS_DEPENDENT_FUNCTION_REPLACEMENTS = new Set<Function>();
 
 // Array
 for (const [original, complexity] of arrayReplacementDefs) {
@@ -417,24 +418,28 @@ for (const [original, complexity] of arrayReplacementDefs) {
     original,
     makeReplacement(original, arrayTicks(complexity, original)),
   );
+  THIS_DEPENDENT_FUNCTION_REPLACEMENTS.add(original);
 }
 
 // String
 for (const [original, complexity] of stringReplacementDefs) {
   if (!original) continue;
   DEFAULT_FUNCTION_REPLACEMENTS.set(original, makeReplacement(original, stringTicks(complexity)));
+  THIS_DEPENDENT_FUNCTION_REPLACEMENTS.add(original);
 }
 
 // Map
 for (const [original, complexity] of mapReplacementDefs) {
   if (!original) continue;
   DEFAULT_FUNCTION_REPLACEMENTS.set(original, makeReplacement(original, mapTicks(complexity)));
+  THIS_DEPENDENT_FUNCTION_REPLACEMENTS.add(original);
 }
 
 // Set
 for (const [original, complexity] of setReplacementDefs) {
   if (!original) continue;
   DEFAULT_FUNCTION_REPLACEMENTS.set(original, makeReplacement(original, setTicks(complexity)));
+  THIS_DEPENDENT_FUNCTION_REPLACEMENTS.add(original);
 }
 
 // TypedArray
@@ -444,6 +449,7 @@ for (const [original, complexity] of typedArrayReplacementDefs) {
     original,
     makeReplacement(original, typedArrayTicks(complexity)),
   );
+  THIS_DEPENDENT_FUNCTION_REPLACEMENTS.add(original);
 }
 
 // Math — O(n) on arg count
@@ -479,6 +485,7 @@ for (const original of regexpReplacementDefs) {
       return typeof input === 'string' ? BigInt(input.length) : 1n;
     }),
   );
+  THIS_DEPENDENT_FUNCTION_REPLACEMENTS.add(original);
 }
 
 // Promise.all/allSettled/race/any — O(n) on iterable length
@@ -501,6 +508,9 @@ for (const [original, complexity] of objectReplacementDefs) {
     original,
     makeReplacement(original, objectTicks(complexity, isStatic)),
   );
+  if (!isStatic) {
+    THIS_DEPENDENT_FUNCTION_REPLACEMENTS.add(original);
+  }
 }
 
 // Array.from — O(n) on source length

--- a/src/utils/functionReplacements.ts
+++ b/src/utils/functionReplacements.ts
@@ -1,12 +1,12 @@
-import type { IContext } from './types';
+import type { IContext, IExecContext } from './types';
 import { SandboxExecutionQuotaExceededError } from './errors';
 
 /**
  * Checks if adding `expectTicks` would exceed the tick limit, and throws SandboxExecutionQuotaExceededError
  * (which bypasses user try/catch) if so. Otherwise increments the tick counter.
  */
-export function checkTicksAndThrow(ctx: IContext, expectTicks: bigint): void {
-  const { ticks } = ctx;
+export function checkTicksAndThrow(ctx: IExecContext, expectTicks: bigint): void {
+  const { ticks } = ctx.ctx;
   if (ticks.tickLimit !== undefined && ticks.tickLimit <= ticks.ticks + expectTicks) {
     throw new SandboxExecutionQuotaExceededError('Execution quota exceeded');
   }
@@ -44,13 +44,13 @@ function isTypedArray(obj: unknown): obj is { length: number } {
 // Helpers to build replacements
 // ---------------------------------------------------------------------------
 
-type Factory = (ctx: IContext) => Function;
+type Factory = (ctx: IExecContext) => Function;
 
 function makeReplacement(
   original: Function,
   getTicks: (thisArg: unknown, args: unknown[]) => bigint,
 ): Factory {
-  return (ctx: IContext) =>
+  return (ctx: IExecContext) =>
     function (this: unknown, ...args: unknown[]) {
       checkTicksAndThrow(ctx, getTicks(this, args));
       return (original as any).apply(this, args);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -42,7 +42,10 @@ export interface IOptions {
   haltOnSandboxError?: boolean;
   maxParserRecursionDepth: number;
   nonBlocking: boolean;
-  functionReplacements: Map<Function, (ctx: IContext) => Function>;
+  functionReplacements: Map<
+    Function,
+    (ctx: IExecContext, builtInReplacement?: Function) => Function
+  >;
 }
 
 export interface IContext {
@@ -56,8 +59,6 @@ export interface IContext {
   options: IOptions;
   auditReport?: IAuditReport;
   ticks: Ticks;
-  /** Resolved replacements cache: maps original fn → replacement fn for this context */
-  functionReplacements: Map<Function, Function>;
 }
 
 export interface IAuditReport {

--- a/test/eval/testCases/function-replacements.data.ts
+++ b/test/eval/testCases/function-replacements.data.ts
@@ -1,0 +1,35 @@
+'use strict';
+import { TestCase } from './types.js';
+
+export const tests: TestCase[] = [
+  {
+    code: "const list = []; const push = list.push; push(1); push(2); return list.join(',')",
+    evalExpect: '1,2',
+    safeExpect: '1,2',
+    category: 'Function Replacements',
+  },
+  {
+    code: 'const list = []; const push = list.push; return push.name',
+    evalExpect: 'push',
+    safeExpect: 'push',
+    category: 'Function Replacements',
+  },
+  {
+    code: "const list = []; const other = []; const push = list.push; const rebound = push.bind(other); rebound(3); return [list.join(','), other.join(','), rebound.name].join('|')",
+    evalExpect: '|3|bound push',
+    safeExpect: '|3|bound push',
+    category: 'Function Replacements',
+  },
+  {
+    code: "const list = []; const other = []; const push = list.push; const rebound = push.bind(other, 3, 4); rebound(); return [list.join(','), other.join(','), rebound.name, rebound.length].join('|')",
+    evalExpect: '|3,4|bound push|0',
+    safeExpect: '|3,4|bound push|0',
+    category: 'Function Replacements',
+  },
+  {
+    code: "const list = []; const other = []; const third = []; const push = list.push; const rebound = push.bind(other, 3); const reboundAgain = rebound.bind(third, 4); reboundAgain(5); return [list.join(','), other.join(','), third.join(','), reboundAgain.name].join('|')",
+    evalExpect: '|3,4,5||bound bound push',
+    safeExpect: '|3,4,5||bound bound push',
+    category: 'Function Replacements',
+  },
+];

--- a/test/eval/testCases/function-replacements.spec.ts
+++ b/test/eval/testCases/function-replacements.spec.ts
@@ -1,0 +1,23 @@
+'use strict';
+import { run, getState } from './test-utils.js';
+import { tests } from './function-replacements.data.js';
+
+describe('Function Replacements Tests', () => {
+  describe('Sync', () => {
+    tests.forEach((test) => {
+      const state = getState();
+      it(test.code.substring(0, 100), async () => {
+        await run(test, state, false);
+      });
+    });
+  });
+
+  describe('Async', () => {
+    tests.forEach((test) => {
+      const state = getState();
+      it(test.code.substring(0, 100), async () => {
+        await run(test, state, true);
+      });
+    });
+  });
+});

--- a/test/eval/testCases/index.ts
+++ b/test/eval/testCases/index.ts
@@ -11,6 +11,7 @@ export { tests as conditionals } from './conditionals.data.js';
 export { tests as dataTypes } from './data-types.data.js';
 export { tests as syntaxErrors } from './syntax-errors.data.js';
 export { tests as errorHandling } from './error-handling.data.js';
+export { tests as functionReplacements } from './function-replacements.data.js';
 export { tests as functions } from './functions.data.js';
 export { tests as logicalOperators } from './logical-operators.data.js';
 export { tests as loops } from './loops.data.js';


### PR DESCRIPTION
## What changed
This PR fixes several sandbox runtime edge cases around function replacement resolution, global access, and compile-time execution context reuse.

## Why it changed
A few code paths were still looking up replacements from the shared sandbox context instead of the per-execution `evals` map, which could lead to inconsistent behavior for wrapped globals and constructors. The branch also tightens own-property checks so inherited properties are not accidentally treated as declared globals or constants.

## User impact
Users get more consistent behavior when accessing or invoking sandboxed globals such as `Function`, `AsyncFunction`, `eval`, and `RegExp`, along with safer property resolution for globals and scopes.

## Root cause
Replacement factories had effectively moved to execution-scoped state, but some call sites and property access helpers were still reading from the old context-level path. A few `in` checks also allowed prototype-chain matches where own-property checks were intended.

## Validation
- `npx jest --runInBand`
- 47 test suites passed
- 1814 tests passed